### PR TITLE
Add config file

### DIFF
--- a/src/OAuth/oAuthBase.php
+++ b/src/OAuth/oAuthBase.php
@@ -148,12 +148,12 @@ class oAuthBase
      */
     protected function getCongfigParameters()
     {
-        $this->apiEndpoint = getenv('MP_API_ENDPOINT', null);
-        $this->oAuthDiscoveryUrl = getenv('MP_OAUTH_DISCOVERY_ENDPOINT', null);
-        $this->mpClientId = getenv('MP_CLIENT_ID', null);
-        $this->mpClientSecret = getenv('MP_CLIENT_SECRET', null);
-        $this->scope = getenv('MP_API_SCOPE', null);
-        $this->mpRedirectURL = getenv('MP_OAUTH_REDIRECT_URL', null);
+        $this->apiEndpoint = config('mp-api-wrapper.MP_API_ENDPOINT');
+        $this->oAuthDiscoveryUrl = config('mp-api-wrapper.MP_OAUTH_DISCOVERY_ENDPOINT');
+        $this->mpClientId = config('mp-api-wrapper.MP_CLIENT_ID');
+        $this->mpClientSecret = config('mp-api-wrapper.MP_CLIENT_SECRET');
+        $this->scope = config('mp-api-wrapper.MP_API_SCOPE');
+        $this->mpRedirectURL = config('mp-api-wrapper.MP_OAUTH_REDIRECT_URL');
 
     }
 

--- a/src/OAuth/oAuthClientCredentials.php
+++ b/src/OAuth/oAuthClientCredentials.php
@@ -34,7 +34,7 @@ class oAuthClientCredentials extends oAuthBase
     public function __construct()
     {
         // Set the account name from configuration, if available
-        $this->accountName = getenv('MP_ACCOUNT_NAME', 'www');
+        $this->accountName = config('mp-api-wrapper.MP_ACCOUNT_NAME');
 
         $this->cacheKey = $this->accountName . '-oAuthCredentials';
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,8 +26,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      * @return void
      */
     public function boot()
-    {
-        
+    {         
+        $this->publishes([
+            __DIR__.'/config/mp-api-wrapper.php' => config_path('mp-api-wrapper.php'),
+        ]);
     }
     
 }

--- a/src/config/mp-api-wrapper.php
+++ b/src/config/mp-api-wrapper.php
@@ -1,0 +1,15 @@
+<?php
+
+return array(
+
+# Current System Info
+"MP_API_ENDPOINT" => "",
+"MP_OAUTH_DISCOVERY_ENDPOINT" => "",
+"MP_API_SCOPE" => "",
+
+# Data from Ministry Platform API Client
+"MP_CLIENT_ID" => "",
+"MP_CLIENT_SECRET" => "",
+"MP_OAUTH_REDIRECT_URL" => "",
+"MP_ACCOUNT_NAME" => "www",
+)


### PR DESCRIPTION
Hi Scott,

I noticed that storing env variables in ```.env``` prevented me from taking advantage of Laravel's configuration caching: ```php artisan config:cache``` - From the [docs](https://laravel.com/docs/9.x/deployment#optimizing-configuration-loading):
```
If you execute the config:cache command during your deployment process, 
you should be sure that you are only calling the env function from within 
your configuration files. Once the configuration has been cached, the 
.env file will not be loaded and all calls to the env function for .env 
variables will return null.
```

### Solution:
- added ```publishes``` method in ```ServiceProvider.php``` pointing to config file at```src/config/mp-api-wrapper.php```
- Replaced all instances of ```getenv()``` with ```config()```
- created config file ```config/mp-api-wrapper.php```

Any chance you could implement this along with the Laravel 9 compatibility updates?